### PR TITLE
edited i_omt.py and ls_tb.py

### DIFF
--- a/src/tsnkit/models/i_omt.py
+++ b/src/tsnkit/models/i_omt.py
@@ -348,10 +348,12 @@ class i_omt:
 
     def get_offset(self) -> utils.Release:
         offset = []
-        for s in self.task:
-            l = s.first_link
-            for k in s.get_frame_indexes(self.task.lcm):
-                offset.append([s, k, self.results[0][self.alpha[s][l][k]].as_long()])
+        for i in range(len(self.results)):
+            for s in self.task:
+                l = s.first_link
+                for k in s.get_frame_indexes(self.task.lcm):
+                    if self.group[s][l][k] == i:
+                        offset.append([s, k, self.results[i][self.alpha[s][l][k]].as_long()])
         return utils.Release(offset)
 
     def get_route(self) -> utils.Route:

--- a/src/tsnkit/models/ls_tb.py
+++ b/src/tsnkit/models/ls_tb.py
@@ -218,7 +218,7 @@ class ls_tb:
                         if _val[1] < l.q_num - 1:
                             _val[1] += 1
                         else:
-                            _val[0] = int(np.inf)
+                            _val[0] = np.inf
                         success = False
                         break
                     if not success:


### PR DESCRIPTION
edit in i_omt:
Edited the get_offset() function in i_omt to get rid of the attribute error 'NoneType has no attribute as_long()'
The original function did not account for the fact that the algorithm solved the schedule in groups, and that self.results had multiple elements corresponding to each of these groups. 
I changed the function so that it searched for the offset in self.results based on the group that the stream and link were in. 

This is the edited get_offset() function:
![image](https://github.com/ChuanyuXue/tsnkit/assets/172156791/a0544234-d6f9-4d19-90ed-cffbd91ce7f5)

edit in ls_tb:
changed line 221 in ls_tb that caused the "cannot convert float infinity to integer" error. changed the code to 
`_val[0] = np.inf` 