### PR TITLE
Update smt_wa.py

### DIFF
--- a/src/tsnkit/models/smt_wa.py
+++ b/src/tsnkit/models/smt_wa.py
@@ -156,9 +156,9 @@ class smt_wa:
                     solver.add(
                         z3.Or(
                             var[s2][l]["phi"] + f2 * s2.period + l.t_sync
-                            <= var[s1][pl_1]["phi"] + f1 * s1.period + pl_1.t_proc,
+                            <= var[s1][pl_1]["phi"] + f1 * s1.period + pl_1.t_prop,
                             var[s1][l]["phi"] + f1 * s1.period + l.t_sync
-                            <= var[s2][pl_2]["phi"] + f2 * s2.period + pl_2.t_proc,
+                            <= var[s2][pl_2]["phi"] + f2 * s2.period + pl_2.t_prop,
                             var[s1][l]["p"] != var[s2][l]["p"],
                         )
                     )


### PR DESCRIPTION
The term should be .t_prop instead of .t_proc, according to the paper "Scheduling Real-Time Communication in IEEE 802.1Qbv Time Sensitive Networks". In the frame isolation constraint, [vx, va].d is the propagation delay of link [vx, va].